### PR TITLE
feature: post new comment functionality

### DIFF
--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -43,7 +43,7 @@ const getFeedPosts = async (req, res, next) => {
 			},
 			{
 				model: User.scope("userProfile"),
-				attributes: ["username", "picturePath"],
+				attributes: ["id", "username", "picturePath"],
 			},
 		],
 		order: [["id", "DESC"]],
@@ -89,6 +89,7 @@ const getUserPosts = async (req, res, next) => {
 			},
 			{
 				model: User.scope("userProfile"),
+				attributes: ["id", "username", "picturePath"],
 			},
 		],
 		order: [["id", "DESC"]],

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -170,8 +170,29 @@ const createComment = async (req, res, next) => {
 		return next(err);
 	}
 
+	let updatedPostComments = await Comment.findAll({
+		where: {
+			postId,
+		},
+		include: [
+			{
+				model: User.scope("userProfile"),
+				attributes: ["firstName", "lastName", "picturePath"],
+			},
+		],
+		order: [["id", "ASC"]],
+	});
+
+	if (!updatedPostComments) {
+		const err = new Error("Failed to get the updated comments for the post.");
+		err.status = 404;
+		err.title = "Failed to get the updated comments for the post.";
+		err.errors = ["Failed to get the updated comments for the post. Refresh this page to manually render."];
+		return next(err);
+	}
+
 	return res.json({
-		newComment,
+		updatedPostComments,
 	}); 
 }; 
 

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -151,5 +151,29 @@ const createPost = async (req, res, next) => {
     }); 
 }
 
+const createComment = async (req, res, next) => { 
+    const { postId } = req.params;
 
-module.exports = { getFeedPosts, getUserPosts, createPost }; 
+    const { userId, description } = req.body;
+
+	const newComment = await Comment.create({
+		postId,
+		userId,
+		description,
+	});
+
+	if (!newComment) {
+		const err = new Error("Failed to post new comment.");
+		err.status = 404;
+		err.title = "Failed to post new comment.";
+		err.errors = ["An error occurred while attempting to post your comment. Please try again."];
+		return next(err);
+	}
+
+	return res.json({
+		newComment,
+	}); 
+}; 
+
+
+module.exports = { getFeedPosts, getUserPosts, createPost, createComment }; 

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -46,7 +46,7 @@ const getFeedPosts = async (req, res, next) => {
 				attributes: ["id", "username", "picturePath"],
 			},
 		],
-		order: [["id", "DESC"]],
+		order: [["id", "DESC"], [Comment, "id", "ASC"]],
 	}); 
 
     if (!posts) { 

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -2,11 +2,14 @@ const express = require('express');
 const router = express.Router(); 
 const asyncHandler = require('express-async-handler'); 
 const { requireAuthentication } = require('../middleware/auth'); 
-const { createPost } = require('../controllers/posts'); 
+const { createPost, createComment } = require('../controllers/posts'); 
 
 /* UPDATE ROUTES */
 
 // POST /posts/
 router.post('/', requireAuthentication, asyncHandler(createPost)); 
+
+// POST /posts/postId/comments
+router.post('/:postId/comments', requireAuthentication, asyncHandler(createComment));
 
 module.exports = router;

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -113,7 +113,7 @@ const Post = ({ post }) => {
 
                 <FormControl>
                     <TextField value={newComment} onChange={updateNewCommentTextfield}/>
-                    <Button onClick={handleNewCommentPost}>POST</Button>
+                    <Button onClick={handleNewCommentPost} disabled={!newComment.length}>POST</Button>
                 </FormControl>
             </Box>
         </Card>

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -113,7 +113,7 @@ const Post = ({ post }) => {
 
                 <FormControl>
                     <TextField value={newComment} onChange={updateNewCommentTextfield}/>
-                    <Button onClick={handleNewCommentPost} disabled={!newComment.length}>POST</Button>
+                    <Button onClick={handleNewCommentPost} disabled={!newComment.trim().length}>POST</Button>
                 </FormControl>
             </Box>
         </Card>

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,9 +1,15 @@
 import { Card, CardMedia, Typography, Box, Divider, IconButton, TextField, FormControl, Button  } from "@mui/material";
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
+import { useState } from "react";
 
 const Post = ({ post }) => { 
     const { createdAt, description, likes, picturePath, Comments: comments, User: {username: authorUsername, picturePath: authorPicturePath } } = post; 
     const formattedDate = `${createdAt.slice(5, 7)}/${createdAt.slice(8,10)}/${createdAt.slice(2, 4)}`; 
+    const [newComment, setNewComment] = useState(''); 
+
+    const updateNewCommentTextfield = (event) => { 
+        setNewComment(event.target.value); 
+    };
 
     return (
         <Card variant="outlined"
@@ -84,7 +90,7 @@ const Post = ({ post }) => {
                 </Box>
 
                 <FormControl>
-                    <TextField />
+                    <TextField value={newComment} onChange={updateNewCommentTextfield}/>
                     <Button>POST</Button>
                 </FormControl>
             </Box>

--- a/frontend/src/store/sessionSlice.js
+++ b/frontend/src/store/sessionSlice.js
@@ -159,6 +159,31 @@ export const getUserPosts = createAsyncThunk(
 	}
 ); 
 
+// new comment submission thunk
+export const postNewComment = createAsyncThunk(
+	"session/postNewComment",
+	async ({ userId, postId, description }, thunkAPI) => {
+
+		const url = `/posts/${postId}/comments`;
+		const options = {
+			method: "POST",
+			body: JSON.stringify({
+				userId,
+				description,
+			}),
+		};
+
+        try {
+			const response = await csrfFetch(url, options);
+			const data = await response.json();
+			return data;
+		} catch (errorResponse) {
+			const errorData = await errorResponse.json();
+			return thunkAPI.rejectWithValue(errorData.errors);
+		}
+	}
+);
+
 export const sessionSlice = createSlice({ 
     name: 'session', 
     initialState: initialState, 


### PR DESCRIPTION
## Description 
This PR adds the ability for a logged-in user to add new comments to existing posts. 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Acceptance Criteria
- [x] the session user is able to add new comments to existing posts 
- [x] a user cannot submit a comment only containing whitespace 

## Updates
### Before
A user was unable to submit new comments to a post. Comments throughout application simply originated from initial database seeding. 


https://github.com/jongranados/social-pet/assets/9102330/07a2c6a9-44e6-45d7-8838-c27142040eb1


### After
A logged-in user is able to submit new comments to existing posts. The targeted post immediately re-renders, displaying the newly submitted comment at the end of the list.


https://github.com/jongranados/social-pet/assets/9102330/627c7cff-0738-4cdf-ae8b-7454d9bade4a


New comments are checked to ensure that there's substance. A user cannot submit a comment only containing whitespace.

https://github.com/jongranados/social-pet/assets/9102330/15eb7031-38cd-463c-9cc6-ba11069c1ab7


