### PR TITLE
feature: liking and unliking a post and displaying its total likes

### DIFF
--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -167,50 +167,48 @@ const createPost = async (req, res, next) => {
     }); 
 }
 
-const createComment = async (req, res, next) => { 
-    const { postId } = req.params;
-
-    const { userId, description } = req.body;
-
-	const newComment = await Comment.create({
-		postId,
-		userId,
-		description,
+const deleteLike = async (req, res, next) => { 
+    const { postId, likeId } = req.params;
+	
+	const deletedLike = await Like.destroy({
+		where: { 
+			id: likeId,
+		}
 	});
 
-	if (!newComment) {
-		const err = new Error("Failed to post new comment.");
+	if (!deletedLike) {
+		const err = new Error("Failed to unlike post.");
 		err.status = 404;
-		err.title = "Failed to post new comment.";
-		err.errors = ["An error occurred while attempting to post your comment. Please try again."];
+		err.title = "Failed to unlike post.";
+		err.errors = ["An error occurred while attempting to unlike the post. Please try again."];
 		return next(err);
 	}
 
-	let updatedPostComments = await Comment.findAll({
+	let updatedPostLikes = await Like.findAll({
 		where: {
 			postId,
 		},
 		include: [
 			{
-				model: User.scope("userProfile"),
-				attributes: ["firstName", "lastName", "picturePath"],
+				model: User,
+				attributes: ["id", "firstName", "lastName", "picturePath"],
 			},
 		],
 		order: [["id", "ASC"]],
 	});
 
-	if (!updatedPostComments) {
-		const err = new Error("Failed to get the updated comments for the post.");
+	if (!updatedPostLikes) {
+		const err = new Error("Failed to get the updated likes for the post.");
 		err.status = 404;
-		err.title = "Failed to get the updated comments for the post.";
-		err.errors = ["Failed to get the updated comments for the post. Refresh this page to manually render."];
+		err.title = "Failed to get the updated likes for the post.";
+		err.errors = ["Failed to get the updated likes for the post. Refresh this page to manually render."];
 		return next(err);
 	}
 
 	return res.json({
-		updatedPostComments,
+		updatedPostLikes,
 	}); 
+
 }; 
 
-
-module.exports = { getFeedPosts, getUserPosts, createPost, createComment }; 
+module.exports = { getFeedPosts, getUserPosts, createPost, deleteLike }; 

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -1,4 +1,4 @@
-const { User, Follow, Post, Comment } = require('../db/models'); 
+const { User, Follow, Post, Comment, Like } = require('../db/models'); 
 
 
 /* READ CONTROLLERS */
@@ -45,8 +45,16 @@ const getFeedPosts = async (req, res, next) => {
 				model: User.scope("userProfile"),
 				attributes: ["id", "username", "picturePath"],
 			},
+			{
+				model: Like, 
+				attributes: ["id"], 
+				include: { 
+					model: User, 
+					attributes: ["firstName", "lastName", "picturePath"],
+				},
+			}
 		],
-		order: [["id", "DESC"], [Comment, "id", "ASC"]],
+		order: [["id", "DESC"], [Comment, "id", "ASC"], [Like, "id", "ASC"]],
 	}); 
 
     if (!posts) { 
@@ -91,8 +99,16 @@ const getUserPosts = async (req, res, next) => {
 				model: User.scope("userProfile"),
 				attributes: ["id", "username", "picturePath"],
 			},
+			{
+				model: Like,
+				attributes: ["id"],
+				include: {
+					model: User,
+					attributes: ["firstName", "lastName", "picturePath"],
+				},
+			},
 		],
-		order: [["id", "DESC"]],
+		order: [["id", "DESC"], [Comment, "id", "ASC"], [Like, "id", "ASC"]],
 	});
 
 	if (!posts) {

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -50,7 +50,7 @@ const getFeedPosts = async (req, res, next) => {
 				attributes: ["id"], 
 				include: { 
 					model: User, 
-					attributes: ["firstName", "lastName", "picturePath"],
+					attributes: ["id", "firstName", "lastName", "picturePath"],
 				},
 			}
 		],
@@ -104,7 +104,7 @@ const getUserPosts = async (req, res, next) => {
 				attributes: ["id"],
 				include: {
 					model: User,
-					attributes: ["firstName", "lastName", "picturePath"],
+					attributes: ["id", "firstName", "lastName", "picturePath"],
 				},
 			},
 		],

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -167,50 +167,6 @@ const createPost = async (req, res, next) => {
     }); 
 }
 
-const deleteLike = async (req, res, next) => { 
-    const { postId, likeId } = req.params;
-	
-	const deletedLike = await Like.destroy({
-		where: { 
-			id: likeId,
-		}
-	});
-
-	if (!deletedLike) {
-		const err = new Error("Failed to unlike post.");
-		err.status = 404;
-		err.title = "Failed to unlike post.";
-		err.errors = ["An error occurred while attempting to unlike the post. Please try again."];
-		return next(err);
-	}
-
-	let updatedPostLikes = await Like.findAll({
-		where: {
-			postId,
-		},
-		include: [
-			{
-				model: User,
-				attributes: ["id", "firstName", "lastName", "picturePath"],
-			},
-		],
-		order: [["id", "ASC"]],
-	});
-
-	if (!updatedPostLikes) {
-		const err = new Error("Failed to get the updated likes for the post.");
-		err.status = 404;
-		err.title = "Failed to get the updated likes for the post.";
-		err.errors = ["Failed to get the updated likes for the post. Refresh this page to manually render."];
-		return next(err);
-	}
-
-	return res.json({
-		updatedPostLikes,
-	}); 
-
-}; 
-
 const createComment = async (req, res, next) => { 
     const { postId } = req.params;
 
@@ -256,4 +212,93 @@ const createComment = async (req, res, next) => {
 	}); 
 }; 
 
-module.exports = { getFeedPosts, getUserPosts, createPost, deleteLike, createComment }; 
+const deleteLike = async (req, res, next) => { 
+    const { postId, likeId } = req.params;
+	
+	const deletedLike = await Like.destroy({
+		where: { 
+			id: likeId,
+		}
+	});
+
+	if (!deletedLike) {
+		const err = new Error("Failed to unlike post.");
+		err.status = 404;
+		err.title = "Failed to unlike post.";
+		err.errors = ["An error occurred while attempting to unlike the post. Please try again."];
+		return next(err);
+	}
+
+	let updatedPostLikes = await Like.findAll({
+		where: {
+			postId,
+		},
+		include: [
+			{
+				model: User,
+				attributes: ["id", "firstName", "lastName", "picturePath"],
+			},
+		],
+		order: [["id", "ASC"]],
+	});
+
+	if (!updatedPostLikes) {
+		const err = new Error("Failed to get the updated likes for the post.");
+		err.status = 404;
+		err.title = "Failed to get the updated likes for the post.";
+		err.errors = ["Failed to get the updated likes for the post. Refresh this page to manually render."];
+		return next(err);
+	}
+
+	return res.json({
+		updatedPostLikes,
+	}); 
+
+}; 
+
+const createLike = async (req, res, next) => { 
+    const { postId } = req.params;
+
+    const { userId } = req.body;
+
+	const newLike = await Like.create({
+		postId,
+		userId,
+	});
+
+	if (!newLike) {
+		const err = new Error("Failed to post new like.");
+		err.status = 404;
+		err.title = "Failed to post new like.";
+		err.errors = ["An error occurred while attempting to like the post. Please try again."];
+		return next(err);
+	}
+
+	let updatedPostLikes = await Like.findAll({
+		where: {
+			postId,
+		},
+		include: [
+			{
+				model: User,
+				attributes: ["id", "firstName", "lastName", "picturePath"],
+			},
+		],
+		order: [["id", "ASC"]],
+	});
+
+	if (!updatedPostLikes) {
+		const err = new Error("Failed to get the updated likes for the post.");
+		err.status = 404;
+		err.title = "Failed to get the updated likes for the post.";
+		err.errors = ["Failed to get the updated likes for the post. Refresh this page to manually render."];
+		return next(err);
+	}
+
+	return res.json({
+		updatedPostLikes,
+	}); 
+}; 
+
+
+module.exports = { getFeedPosts, getUserPosts, createPost, createComment, deleteLike, createLike }; 

--- a/backend/controllers/posts.js
+++ b/backend/controllers/posts.js
@@ -47,7 +47,7 @@ const getFeedPosts = async (req, res, next) => {
 			},
 			{
 				model: Like, 
-				attributes: ["id"], 
+				attributes: ["id", "postId"], 
 				include: { 
 					model: User, 
 					attributes: ["id", "firstName", "lastName", "picturePath"],
@@ -101,7 +101,7 @@ const getUserPosts = async (req, res, next) => {
 			},
 			{
 				model: Like,
-				attributes: ["id"],
+				attributes: ["id", "postId"],
 				include: {
 					model: User,
 					attributes: ["id", "firstName", "lastName", "picturePath"],

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router(); 
 const asyncHandler = require('express-async-handler'); 
 const { requireAuthentication } = require('../middleware/auth'); 
-const { createPost, createComment } = require('../controllers/posts'); 
+const { createPost, createComment, createLike, deleteLike } = require('../controllers/posts'); 
 
 /* UPDATE ROUTES */
 
@@ -11,5 +11,11 @@ router.post('/', requireAuthentication, asyncHandler(createPost));
 
 // POST /posts/postId/comments
 router.post('/:postId/comments', requireAuthentication, asyncHandler(createComment));
+
+// POST /posts/postId/likes
+router.post('/:postId/likes', requireAuthentication, asyncHandler(createLike)); 
+
+// DELETE /posts/postId/likes/likeId
+router.delete('/:postId/likes/:likeId', requireAuthentication, asyncHandler(deleteLike)); 
 
 module.exports = router;

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,16 +1,18 @@
 import { Card, CardMedia, Typography, Box, Divider, IconButton, TextField, FormControl, Button  } from "@mui/material";
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
+import Favorite from '@mui/icons-material/Favorite';
 import { useState } from "react";
 import { useDispatch,  useSelector } from 'react-redux'; 
 import * as sessionActions from '../store/sessionSlice'; 
 
 const Post = ({ post }) => { 
-    const { id: postId, createdAt, description, likes, picturePath, Comments, User: { username: authorUsername, picturePath: authorPicturePath } } = post; 
+    const { id: postId, createdAt, description, picturePath, Comments, Likes: likes, User: { username: authorUsername, picturePath: authorPicturePath } } = post; 
     const formattedDate = `${createdAt.slice(5, 7)}/${createdAt.slice(8,10)}/${createdAt.slice(2, 4)}`; 
     const user = useSelector(state => state.session.user);
     const dispatch = useDispatch(); 
     const [comments, setComments] = useState(Comments); 
     const [newComment, setNewComment] = useState(''); 
+    const isLiked = likes.some((like) => user.id === like.User.id); 
 
     const handleNewCommentPost = async() => { 
         // dispatch redux post-new-comment thunk
@@ -103,11 +105,11 @@ const Post = ({ post }) => {
                 <Divider />
                 <Box> 
                     <IconButton>
-                        <FavoriteBorder />
+                        {isLiked ? <Favorite /> : <FavoriteBorder />}
                     </IconButton>
 
                     <Typography>
-                        {`${likes} likes`}
+                        {`${likes.length} likes`}
                     </Typography>
                 </Box>
 

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -12,8 +12,8 @@ const Post = ({ post }) => {
     const dispatch = useDispatch(); 
     const [comments, setComments] = useState(Comments); 
     const [newComment, setNewComment] = useState(''); 
-    const isLiked = likes.some((like) => user.id === like.User.id); 
-
+    const isLiked = likes.find((like) => user.id === like.User.id); 
+    
     const handleNewCommentPost = async() => { 
         // dispatch redux post-new-comment thunk
         await dispatch(sessionActions.postNewComment({ userId: user.id, postId, description: newComment }))
@@ -31,11 +31,34 @@ const Post = ({ post }) => {
             });
     }; 
 
+    const handleUpdateLikes = async() => { 
+        if (isLiked) { 
+            // dispatch redux delete-like thunk
+            await dispatch(sessionActions.deletePostLike({ postId, likeId: isLiked.id }))
+                // unwrap promise returned from delete-like thunk in order to handle failed requests at component level
+                .unwrap()
+                // handle errors returned from failed delete-like request
+                .catch(async backendValidationErrors => {
+                    alert(backendValidationErrors) 
+                });
+        } else { 
+            // dispatch redux post-new-like thunk
+            await dispatch(sessionActions.createPostLike({ postId, userId: user.id }))
+                // unwrap promise returned from post-new-like thunk in order to handle failed requests at component level
+                .unwrap()
+                // handle errors returned from failed post-new-like request
+                .catch(async backendValidationErrors => {
+                    alert(backendValidationErrors) 
+                });
+
+        }
+    }
+
     const updateNewCommentTextfield = (event) => { 
         setNewComment(event.target.value); 
     };
 
-    return (
+    return (       
         <Card variant="outlined"
         sx={{
             display: 'flex',
@@ -104,7 +127,7 @@ const Post = ({ post }) => {
 
                 <Divider />
                 <Box> 
-                    <IconButton>
+                    <IconButton onClick={handleUpdateLikes}>
                         {isLiked ? <Favorite /> : <FavoriteBorder />}
                     </IconButton>
 

--- a/frontend/src/scenes/homePage/UserFeed.jsx
+++ b/frontend/src/scenes/homePage/UserFeed.jsx
@@ -41,7 +41,7 @@ const UserFeed = () => {
             }}
         
         >
-            {feedPosts.map((post) => <Post key={`post-${post.id}`} post={post} /> )}
+            {feedPosts.map((post) => <Post key={`post-${post.id}`} sessionUserId={user.id} post={post} /> )}
         </Box>
     )
 }

--- a/frontend/src/store/sessionSlice.js
+++ b/frontend/src/store/sessionSlice.js
@@ -210,6 +210,35 @@ export const deletePostLike = createAsyncThunk(
 	}
 );
 
+// create a new record in the like resource
+export const createPostLike = createAsyncThunk(
+	"session/createPostLike",
+	async ({ userId, postId }, thunkAPI) => {
+		const url = `posts/${postId}/likes`;
+		const options = {
+			method: "POST",
+			body: JSON.stringify({
+				userId,
+			}),
+		};
+
+		try {
+			const response = await csrfFetch(url, options);
+			const data = await response.json();
+            thunkAPI.dispatch(
+				updateFeedPostLikes({
+					targetPostId: postId,
+					updatedPostLikes: data.updatedPostLikes,
+				})
+			); 
+			return data;
+		} catch (errorResponse) {
+			const errorData = await errorResponse.json();
+			return thunkAPI.rejectWithValue(errorData.errors);
+		}
+	}
+);
+
 export const sessionSlice = createSlice({ 
     name: 'session', 
     initialState: initialState, 

--- a/frontend/src/store/sessionSlice.js
+++ b/frontend/src/store/sessionSlice.js
@@ -184,6 +184,32 @@ export const postNewComment = createAsyncThunk(
 	}
 );
 
+// delete a record from the like resource
+export const deletePostLike = createAsyncThunk(
+	"session/deletePostLike",
+	async ({ postId, likeId }, thunkAPI) => {
+		const url = `posts/${postId}/likes/${likeId}`;
+		const options = {
+			method: "DELETE",
+		};
+
+		try {
+			const response = await csrfFetch(url, options);
+			const data = await response.json();
+            thunkAPI.dispatch(
+				updateFeedPostLikes({
+					targetPostId: postId,
+					updatedPostLikes: data.updatedPostLikes,
+				})
+			);
+			return data;
+		} catch (errorResponse) {
+			const errorData = await errorResponse.json();
+			return thunkAPI.rejectWithValue(errorData.errors);
+		}
+	}
+);
+
 export const sessionSlice = createSlice({ 
     name: 'session', 
     initialState: initialState, 
@@ -203,15 +229,11 @@ export const sessionSlice = createSlice({
         setFeedPosts(state, action) { 
             state.feedPosts = action.payload; 
         }, 
-        // // to-do
-        // setPost(state, action) { 
-            
-        // }
     },
 }); 
 
 // export session action creators
-export const { setMode, setUser, removeUser, setFollowing, setFeedPosts, } = sessionSlice.actions;
+export const { setMode, setUser, removeUser, setFollowing, setFeedPosts, updateFeedPostLikes } = sessionSlice.actions;
 
 // export session reducer
 export default sessionSlice.reducer; 

--- a/frontend/src/store/sessionSlice.js
+++ b/frontend/src/store/sessionSlice.js
@@ -229,6 +229,16 @@ export const sessionSlice = createSlice({
         setFeedPosts(state, action) { 
             state.feedPosts = action.payload; 
         }, 
+        updateFeedPostLikes(state, action) { 
+            const { targetPostId, updatedPostLikes } = action.payload; 
+            for (let i = 0; i < state.feedPosts.length; i++) { 
+                const feedPost = state.feedPosts[i]; 
+                if (feedPost.id === targetPostId) { 
+                    feedPost.Likes = updatedPostLikes; 
+                    break; 
+                }
+            }
+        }
     },
 }); 
 


### PR DESCRIPTION
## Description 
This PR adds the ability for a logged-in user to like and unlike posts on their feed. 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Acceptance Criteria
- [x] the session user is able to like a post on their feed 
- [x] the session user is able to unlike a post on their feed 
- [x] the application dynamically renders the state of whether or not the session user has liked a post
- [x] the application dynamically displays the total number of likes a post has received

## Updates
### Before
A user was unable to like and unlike posts as the application did not support it. 

https://github.com/jongranados/social-pet/assets/9102330/2bedf7a8-b3f4-4b26-b2d0-ec7fdaca52fe

### After
A logged-in user is able to like and unlike posts on their feed. The targeted post immediately re-renders, actively displaying the state of whether a user has liked a post or not as well as the total number of likes the post has received.

https://github.com/jongranados/social-pet/assets/9102330/51effdb0-d5f2-493a-a3d5-b2e3fb8baed9
